### PR TITLE
Allow more architectures to be installed, including arm64 for m1 chips

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -26,7 +26,7 @@ install_tilt() {
   rm "${install_path}/tilt.tar.gz"
 }
 
-get_arch() {
+get_platform() {
   arch=$(uname | tr '[:upper:]' '[:lower:]')
   case ${arch} in
   darwin)
@@ -40,10 +40,16 @@ get_arch() {
   echo ${arch}
 }
 
+get_arch() {
+  # the tilt builds arch names match the output of uname -m exactly.
+  uname -m
+}
+
 get_download_url() {
   local version="$1"
-  local platform="$(get_arch)"
-  echo "https://github.com/tilt-dev/tilt/releases/download/v${version}/tilt.${version}.${platform}.x86_64.tar.gz"
+  local platform="$(get_platform)"
+  local arch=$(get_arch)
+  echo "https://github.com/tilt-dev/tilt/releases/download/v${version}/tilt.${version}.${platform}.${arch}.tar.gz"
 }
 
 install_tilt $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH


### PR DESCRIPTION
This change allows this tilt plugin to work across all architectures released by the tilt project, not just x86_64. This is key as more and more engineers adopt m1 machines (for good or ill, I just need to support 'em).

Thanks!