### PR TITLE
support aarch64 machines

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -42,7 +42,7 @@ get_platform() {
 
 get_arch() {
   # the tilt builds arch names match the output of uname -m exactly.
-  uname -m
+  uname -m | sed 's/aarch64/arm64/'
 }
 
 get_download_url() {


### PR DESCRIPTION
Certain devices, such as Raspberry Pi, return `aarch64` when executing `uname -m`. To maintain consistency, map aarch64 to arm64.

Fixes #5 